### PR TITLE
fix bug: double free or segment fault

### DIFF
--- a/src/header.cpp
+++ b/src/header.cpp
@@ -43,10 +43,13 @@ HeadDataNode::~HeadDataNode() {
 //HeadData::HeadData(const HeadDataNode &that);
 HeadData::~HeadData() {
     HeadDataNode *it;
-
-    for (it = head; it != NULL; it = it->next) {
+    HeadDataNode *tmp;
+    for (it = head; it != NULL;) {
+        tmp = it->next;
         delete it;
+        it = tmp;
     }
+    head = NULL;
 };
 
 //HeadData& 
@@ -117,11 +120,12 @@ int HeadData::remove_attr(const char *attrName) {
 
 void HeadData::remove_all() {
     HeadDataNode *it;
-
-    for (it = head; it != NULL; it = it->next) {
+    HeadDataNode *tmp;
+    for (it = head; it != NULL;) {
+        tmp = it->next;
         delete it;
+        it = tmp;
     }
-
     head = NULL;
 };
 


### PR DESCRIPTION
fix bug: double free or segment fault
when it is deleted, we can not use it->next any more.
