### PR TITLE
Introduce "-H, --host=host" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Usage
 	  -t,  --timeout=num    Set the connection timeout to [num] seconds, the default is "30"
 	  -v,  --version        Show the version of the myget and exit
 	  -x,  --proxy=URL      Set the proxy [URL]
+	  -H,  --host=host      Modify `Host: [host]' header in HTTP request.

--- a/rpm/mytget-build.sh
+++ b/rpm/mytget-build.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Initial variables
+topdir=$1
+name=$2
+version=$3
+release=$4
+
+# Echo shell commands
+set -x
+
+# Change to topdir
+cd $topdir
+
+# Verify and adjust $name/$version variables
+spec_name=`cat $topdir/rpm/mytget.spec |
+	grep -E "^Name:" |
+	sed -n -e 's/: \?/ /' -e 's/ \+/:/gp' |
+	awk -F ':' '{print $2}'`
+
+spec_version=`cat $topdir/rpm/mytget.spec |
+	grep -E "^Version:" |
+	sed -n -e 's/: \?/ /' -e 's/ \+/:/gp' |
+	awk -F ':' '{print $2}'`
+
+if [ $name != $spec_name ]
+then
+    echo "Warning: name is unexpected! Use spec_name instead."
+    name=$spec_name
+fi
+
+if [ $version != $spec_version ]
+then
+    echo "Warning: version is unexpected! Use spec_version instead."
+    version=$spec_version
+fi
+
+# Create rpm source: $name-$version.tar.gz
+project=$name-$version
+rm -rf $project.tar.gz $project
+test -d .git && git clone . $project || svn export . $project
+rm -rf $project/autom4te.cache $project/.git
+tar -czf $project.tar.gz $project && rm -rf $project
+
+# Let's go to create rpm
+cd $topdir/rpm
+rpm_create $name.spec -v $version -r $release -p /usr/local/bin -k
+#rpmbuild -ba $name.spec

--- a/rpm/mytget-buildpe.sh
+++ b/rpm/mytget-buildpe.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Initial variables
+topdir=$1
+name=$2
+version=$3
+release=$4
+
+# Echo shell commands
+set -x
+
+cd $topdir/rpm
+
+if [ `uname -i` == "x86_64" ]
+then
+    plat="x86_64"
+else
+    plat="i386"
+fi
+
+for name in `ls *.rpm`
+do
+    name=${name/.rpm/}
+    yum-setbranch $name   $ABS_OS  ${plat} current
+done

--- a/rpm/mytget-buildqa.sh
+++ b/rpm/mytget-buildqa.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Initial variables
+topdir=$1
+name=$2
+version=$3
+release=$4
+
+# Echo shell commands
+set -x
+
+cd $topdir/rpm
+
+if [ `uname -i` == "x86_64" ]
+then
+    plat="x86_64"
+else
+    plat="i386"
+fi
+
+for name in `ls *.rpm`
+do
+    yum-upload $name  --osver $ABS_OS --arch ${plat} --group yum --batch
+done

--- a/rpm/mytget.spec
+++ b/rpm/mytget.spec
@@ -1,0 +1,47 @@
+##############################################################
+# http://baike.corp.taobao.com/index.php/%E6%B7%98%E5%AE%9Drpm%E6%89%93%E5%8C%85%E8%A7%84%E8%8C%83 #
+# http://www.rpm.org/max-rpm/ch-rpm-inside.html              #
+##############################################################
+Name: mytget
+Version: 1.12.0
+Release: %(echo $RELEASE)%{?dist}
+Summary: Myget is a muti-thread downloader accelerator for GNU/Linux.
+Group: System Environment/Daemons
+Source: %{name}-%{version}.tar.gz
+License: Commercial
+URL: http://gitlab.alibaba-inc.com/alicdn/Mytget/blob/master/README.md
+#BuildRequires: tops-python27, gcc >= 4.2, make >= 3.81
+#Requires: package_name = 1.0.0
+
+# disable debuginfo checking
+%global debug_package %{nil}
+
+%description
+Myget is a muti-thread downloader accelerator for GNU/Linux.
+
+%prep
+%setup -q
+
+%build
+pwd
+cmake .
+make
+
+%install
+pwd
+echo %{buildroot}
+mkdir -p %{buildroot}/%{_prefix}
+cp -r `pwd`/src/mytget %{buildroot}/%{_prefix}/
+
+%files
+%defattr(0755, root, root, 0755)
+%{_prefix}/mytget
+
+%pre
+#%post -p /sbin/ldconfig
+#%postun -p /sbin/ldconfig
+%clean
+
+%changelog
+* Wed Feb 25 2015 qiushu.zyk
+* - add spec of mytget

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -88,7 +88,6 @@ int Http::connect(const char *host, int port) {
 #endif
 
     conn->get_remote_addr(remote);
-    set_host(host, port);
 
     return 0;
 };
@@ -253,7 +252,7 @@ Http::post(const char *url)
 };
 #endif
 
-/* the normal head just like this 
+/* the normal head just like this
 HTTP/1.1 200 OK
 Date: Tue, 03 May 2005 07:37:36 GMT
 Server: Apache/2.0.52 (Gentoo/Linux) PHP/4.3.10

--- a/src/httpplugin.cpp
+++ b/src/httpplugin.cpp
@@ -48,6 +48,12 @@ int HttpPlugin::get_info(Task *task) {
         http.header("Referer", task->url.get_url());
     }
 
+    if (task->get_host() != NULL) {
+        http.header("Host", task->get_host());
+    } else {
+        http.set_host(task->url.get_host(), task->url.get_port());
+    }
+
     if (task->fileSize > 0) {
         // test the Range
         http.set_range(1);
@@ -60,7 +66,9 @@ int HttpPlugin::get_info(Task *task) {
         if (http.connect(task->proxy.get_host(), task->proxy.get_port()) < 0) {
             return -2;
         }
-        http.set_host(task->url.get_host(), task->url.get_port());
+        if (task->get_host() == NULL) {
+            http.set_host(task->url.get_host(), task->url.get_port());
+        }
         if (task->proxy.get_user() != NULL) {
             http.proxy_auth(task->proxy.get_user(),
                     task->proxy.get_password() ? task->proxy.get_password() : "");
@@ -197,11 +205,19 @@ int HttpPlugin::download(Task& task, Block *block) {
         http.header("Referer", task.url.get_url());
     }
 
+    if (task.get_host() != NULL) {
+        http.header("Host", task.get_host());
+    } else {
+        http.set_host(task.url.get_host(), task.url.get_port());
+    }
+
     if (task.proxy.get_type() == HTTP_PROXY) {
         if (http.connect(task.proxy.get_host(), task.proxy.get_port()) < 0) {
             return -2;
         }
-        http.set_host(task.url.get_host(), task.url.get_port());
+        if (task.get_host() == NULL) {
+            http.set_host(task.url.get_host(), task.url.get_port());
+        }
         if (task.proxy.get_user() != NULL) {
             http.proxy_auth(task.proxy.get_user(),
                     task.proxy.get_password() ? task.proxy.get_password() : "");

--- a/src/mytget.cpp
+++ b/src/mytget.cpp
@@ -47,6 +47,7 @@ void print_help() {
     cout << "  -t,  --timeout=num    Set the connection timeout to [num] seconds, the default is \"30\"" << endl;
     cout << "  -v,  --version        Show the version of the myget and exit" << endl;
     cout << "  -x,  --proxy=URL      Set the proxy [URL]" << endl;
+    cout << "  -H,  --host=host      Modify `Host: [host]\' header in HTTP request." << endl;
 };
 
 const struct option long_options[] = {
@@ -61,10 +62,11 @@ const struct option long_options[] = {
     {"timeout", 1, NULL, 't'},
     {"version", 0, NULL, 'v'},
     {"proxy", 1, NULL, 'x'},
+    {"host", 1, NULL, 'H'},
     {NULL, 0, NULL, 0}
 };
 
-char short_options[] = "bc:d:f:hi:n:r:t:vx:";
+char short_options[] = "bc:d:f:hi:n:r:t:vx:H:";
 
 int main(int argc, char **argv) {
     int ret;
@@ -126,6 +128,9 @@ int main(int argc, char **argv) {
                 return 0;
             case 'x':
                 ptr = StrDup(optarg);
+                break;
+            case 'H':
+                task.set_host(optarg);
                 break;
             case '?':
             default:

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -33,12 +33,14 @@ Task::Task() {
     localDir = NULL;
     localFile = NULL;
     referer = NULL;
+    host = NULL;
 };
 
 Task::~Task() {
     delete[] localDir;
     delete[] localFile;
     delete[] referer;
+    delete[] host;
 };
 
 Task& Task::operator = (Task& task) {
@@ -47,9 +49,11 @@ Task& Task::operator = (Task& task) {
     delete[] localDir;
     delete[] localFile;
     delete[] referer;
+    delete[] host;
     localDir = StrDup(task.get_local_dir());
     localFile = StrDup(task.get_local_file());
     referer = StrDup(task.get_referer());
+    host = StrDup(task.get_host());
     fileSize = task.fileSize;
     isDirectory = task.isDirectory;
     resumeSupported = task.resumeSupported;
@@ -76,6 +80,10 @@ const char* Task::get_referer() {
     return referer;
 };
 
+const char* Task::get_host() {
+    return host;
+};
+
 void Task::set_local_dir(const char *dir) {
     delete[] localDir;
     localDir = StrDup(dir);
@@ -91,3 +99,7 @@ void Task::set_referer(const char *referer) {
     this->referer = StrDup(referer);
 };
 
+void Task::set_host(const char *host) {
+    delete[] this->host;
+    this->host= StrDup(host);
+};

--- a/src/task.h
+++ b/src/task.h
@@ -37,9 +37,11 @@ class Task {
         const char* get_local_dir();
         const char* get_local_file();
         const char* get_referer();
+        const char* get_host();
         void set_local_dir(const char *dir);
         void set_local_file(const char *file);
         void set_referer(const char *referer);
+        void set_host(const char *host);
         Task& operator = (Task& task);
 
     public:
@@ -58,6 +60,7 @@ class Task {
         char *localDir;
         char *localFile;
         char *referer;
+        char *host;
 };
 
 #endif  // TASK_H_


### PR DESCRIPTION
This patch will introduce "-H, --host=host" option, which can be
used to modify "Host: [host]" header in HTTP request.